### PR TITLE
Changed ordering parameter to UserId

### DIFF
--- a/user.py
+++ b/user.py
@@ -94,7 +94,7 @@ class User(Base, IIQ):
 
     @staticmethod
     def get_data_request(page):
-        url = "http://" + config.IIQ_INSTANCE + "/services/users?$o=FullName&$s=" + str(
+        url = "http://" + config.IIQ_INSTANCE + "/services/users?$o=UserId&$s=" + str(
             config.PAGE_SIZE) + "&$d=Ascending&$p=" + str(page)
         payload = {}
         files = {}


### PR DESCRIPTION
Having FullName as the sorting parameter is not a good idea, as there can be multiple people with the same name. The ordering for the users with the same full name will not be consistent and hence creates issues while paginating a lot of info , giving duplicate entries.